### PR TITLE
Add CI/CD Pipeline

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,37 @@
+name-template: "$RESOLVED_VERSION"
+tag-template: "$RESOLVED_VERSION"
+categories:
+  - title: "🚀 Features"
+    labels:
+      - "feature"
+      - "enhancement"
+  - title: "🐛 Bug Fixes"
+    labels:
+      - "fix"
+      - "bugfix"
+      - "bug"
+  - title: "🧹 Maintenance"
+    labels:
+      - "chore"
+      - "dependencies"
+version-resolver:
+  major:
+    labels:
+      - "feature"
+  minor:
+    labels:
+      - "enhancement"
+  patch:
+    labels:
+      - "fix"
+      - "bugfix"
+      - "bug"
+      - "chore"
+      - "dependencies"
+  default: patch
+template: |
+  ## Changes
+
+  $CHANGES
+
+  **Full Changelog**: https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...$RESOLVED_VERSION

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,41 @@
+name: Integration
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup go
+        uses: actions/setup-go@v3
+        with:
+          go-version-file: "go.mod"
+          cache: true
+
+      - name: Test
+        run: go test -coverprofile=coverage.txt -covermode=atomic ./...
+
+  build:
+    name: Build
+    runs-on: ubuntu-22.04
+    needs: [test]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup go
+        uses: actions/setup-go@v3
+        with:
+          go-version-file: "go.mod"
+          cache: true
+
+      - name: Build
+        run: go build

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,18 @@
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  release-drafter:
+    name: Release Drafter
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Publish Release
+        uses: release-drafter/release-drafter@v5
+        with:
+          publish: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,27 @@
+name: Release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup go
+        uses: actions/setup-go@v3
+        with:
+          go-version-file: "go.mod"
+          cache: true
+
+      - name: Build Releases
+        uses: goreleaser/goreleaser-action@v4.2.0
+        with:
+          version: latest
+          args: release --rm-dist
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,24 @@
+builds:
+  - env:
+      - CGO_ENABLED=0
+    goarch:
+      - amd64
+      - arm
+      - arm64
+    goos:
+      - darwin
+      - linux
+      - windows
+    goarm:
+      - "6"
+      - "7"
+    ldflags:
+      - "-s -w"
+      - "-X main.GitCommit={{ .Commit }}"
+      - "-X main.GitVersion={{ .Version }}"
+checksum:
+  name_template: "checksums.txt"
+snapshot:
+  name_template: "{{ .Tag }}-next"
+changelog:
+  skip: true


### PR DESCRIPTION
This PR adds CI/CD Workflows for the Mumble Exporter.

It will does the following:

1. Generate a drafted Release with Changelog using [release-drafter](https://github.com/release-drafter/release-drafter).
2. It tests and build the binaries for Pull Requests and commits to main
3. When a GitHub Release is published [Goreleaser](https://goreleaser.com/) will build the binaries, generating a checksum file and attach the generated files to the release.

Fixes

- #5 