### PR TITLE
🐛 Fix permissions for GitHub Actions

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
 
+permissions:
+  contents: write
+  pull-requests: read
+
 jobs:
   release-drafter:
     name: Release Drafter

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,9 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: write
+
 jobs:
   release:
     name: Release


### PR DESCRIPTION
I found a problem in my PR (#6). The Release Drafter has not the necassary permissions to update the GitHub release. Here is the fix. I also changed that to be more explicit in the release action itself.